### PR TITLE
fix: Fixed the CodeQL version

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,12 +24,12 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
+        uses: github/codeql-action/autobuild@v2
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
Fix CodeQL scanning version based on this post. [Code scanning: deprecation of CodeQL Action v1](https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/#exactly-what-do-i-need-to-change)